### PR TITLE
Fix example_weighted.sh

### DIFF
--- a/minsize_kmeans/example_weighted.sh
+++ b/minsize_kmeans/example_weighted.sh
@@ -19,5 +19,5 @@
 # The total weight of points in each cluster should be at most 4000
 # Run the algorithm 2 times and ouput the best clustering
 # Store the results in the file wmm.out
-./weighted_mm_kmeans.py ../data/iris.data 3 ../data/iris.weights 2000 4000 -n 2 -o wmm.out
+./weighted_mm_kmeans.py ../data/iris.data 3 ../data/iris.weights 2000 4000 -n 2 -o wmm2.out
 

--- a/minsize_kmeans/example_weighted.sh
+++ b/minsize_kmeans/example_weighted.sh
@@ -6,10 +6,18 @@
 # The weights of data points are stored in the file ../data/iris.weights
 # number of clusters: 3
 # The total weight of points in each cluster should be at least 1
-# The total weight of points in each cluster should be at most 150
+# The total weight of points in each cluster should be at most 4000
 # Run the algorithm 2 times and ouput the best clustering
 # Store the results in the file wmm.out
-./weighted_mm_kmeans.py ../data/iris.data 3 ../data/iris.weights 1 50 -n 2 -o wmm.out
+./weighted_mm_kmeans.py ../data/iris.data 3 ../data/iris.weights 1 4000 -n 2 -o wmm.out
 
 
+# Run k-means on the data stored in the file ../data/iris.data
+# The weights of data points are stored in the file ../data/iris.weights
+# number of clusters: 3
+# The total weight of points in each cluster should be at least 2000
+# The total weight of points in each cluster should be at most 4000
+# Run the algorithm 2 times and ouput the best clustering
+# Store the results in the file wmm.out
+./weighted_mm_kmeans.py ../data/iris.data 3 ../data/iris.weights 2000 4000 -n 2 -o wmm.out
 


### PR DESCRIPTION
make clustering possible with the example data.
Previous example had the parameters make classification impossible (since the maximal weight 50 was too constraining for the dataset with weight sum around 7,000) and also mismatch with the comment text which stated maximal weight 150.
Changed it to include two examples. One almost doesn't constrain the minimal weight (min_weight=1) and one constrains it to 2,000 so the resulting clustering is different.