### PR TITLE
In `minsize_kmeans()`, use argument `dataset` instead of global

### DIFF
--- a/minsize_kmeans/run_mskmeans.py
+++ b/minsize_kmeans/run_mskmeans.py
@@ -104,7 +104,7 @@ def minsize_kmeans(dataset, k, min_size=0):
 
     converged = False
     while not converged:
-        m = subproblem(centers, data, min_size)
+        m = subproblem(centers, dataset, min_size)
         clusters_ = m.solve()
         if not clusters_:
             return None, None


### PR DESCRIPTION
variable `data`, which only happens to equal the argument when `run_mskmeans.py` is executed from the command line.
Right now, calling `minsize_kmeans()` from another file will lead to an exception because `data` is not defined.