### PR TITLE
Greatly speed up computation by building pulp constraints and objective with lpSum, not sum

### DIFF
--- a/minsize_kmeans/run_mskmeans.py
+++ b/minsize_kmeans/run_mskmeans.py
@@ -6,7 +6,7 @@ import random
 import argparse
 
 def l2_distance(point1, point2):
-    return sum([(float(i)-float(j))**2 for (i,j) in zip(point1, point2)])
+    return sum((float(i)-float(j))**2 for (i,j) in zip(point1, point2))
 
 class subproblem(object):
     def __init__(self, centroids, data, min_size):
@@ -44,18 +44,18 @@ class subproblem(object):
         self.model = pulp.LpProblem("Model for assignment subproblem", pulp.LpMinimize)
 
         # objective function
-        self.model += sum([distances(assignment) * self.y[assignment] for assignment in assignments])
+        self.model += pulp.lpSum(distances(assignment) * self.y[assignment] for assignment in assignments)
 
         # flow balance constraints for data nodes
         for i in range(self.n):
-            self.model += sum(self.y[(i, j)] for j in range(self.k)) == 1
+            self.model += pulp.lpSum(self.y[(i, j)] for j in range(self.k)) == 1
 
         # flow balance constraints for cluster nodes
         for j in range(self.k):
-            self.model += sum(self.y[(i, j)] for i in range(self.n)) - self.min_size == self.b[j]
+            self.model += pulp.lpSum(self.y[(i, j)] for i in range(self.n)) - self.min_size == self.b[j]
 
         # flow balance constraint for the sink node
-        self.model += sum(self.b[j] for j in range(self.k)) == self.n - (self.k * self.min_size)
+        self.model += pulp.lpSum(self.b[j] for j in range(self.k)) == self.n - (self.k * self.min_size)
 
 
     def solve(self):


### PR DESCRIPTION
For my use case (~2000 nodes, ~50 dimensions, k≈50), this brings down iteration time from hours to seconds, and even on the example run (`./run_mskmeans.py ../data/iris.data 3 2 -n 2 -o ./clusters.out`), it reduces total running time from 50ms to 35ms on my system.
On my large example, I noticed that running time was terrible, even though gurobi reported split-second computation per iteration. Profiling showed that most time was spent in setting up the pulp LP. As reported on https://groups.google.com/forum/#!topic/pulp-or-discuss/p1N2fkVtYyM , building constraints with `sum` is much slower than handing a list of summands to `lpSum`.
Probably, similar changes should be made for the weighted version.