### PR TITLE
convert sum to pulp.lpSum for speed

### DIFF
--- a/minsize_kmeans/minmax_kmeans.py
+++ b/minsize_kmeans/minmax_kmeans.py
@@ -45,22 +45,22 @@ class subproblem(object):
         self.model = pulp.LpProblem("Model for assignment subproblem", pulp.LpMinimize)
 
         # objective function
-        self.model += sum([distances(assignment) * self.y[assignment] for assignment in assignments])
+        self.model += pulp.lpSum([distances(assignment) * self.y[assignment] for assignment in assignments])
 
         # flow balance constraints for data nodes
         for i in range(self.n):
-            self.model += sum(self.y[(i, j)] for j in range(self.k)) == 1
+            self.model += pulp.lpSum(self.y[(i, j)] for j in range(self.k)) == 1
 
         # flow balance constraints for cluster nodes
         for j in range(self.k):
-            self.model += sum(self.y[(i, j)] for i in range(self.n)) - self.min_size == self.b[j]
+            self.model += pulp.lpSum(self.y[(i, j)] for i in range(self.n)) - self.min_size == self.b[j]
             
         # capacity constraint on outflow of cluster nodes
         for j in range(self.k):
             self.model += self.b[j] <= self.max_size - self.min_size 
 
         # flow balance constraint for the sink node
-        self.model += sum(self.b[j] for j in range(self.k)) == self.n - (self.k * self.min_size)
+        self.model += pulp.lpSum(self.b[j] for j in range(self.k)) == self.n - (self.k * self.min_size)
 
 
     def solve(self):


### PR DESCRIPTION
https://stackoverflow.com/questions/26643421/pulp-very-slow-when-adding-many-constraints

On my tests with a relatively small example (270 X 2) the original took less than a second but almost five minutes on a larger problem (1202 X 2). After the lpSum conversion the larger problem takes about 2 seconds.