### PR TITLE
Changed "xrange" to "range" in line120

### DIFF
--- a/minsize_kmeans/weighted_mm_kmeans.py
+++ b/minsize_kmeans/weighted_mm_kmeans.py
@@ -124,7 +124,7 @@ def minsize_kmeans_weighted(dataset, k, weights=None, min_weight=0, max_weight=N
             return None, None
         clusters_, centers = compute_centers(clusters_, dataset)
 
-        converged = all([clusters[i]==clusters_[i] for i in xrange(n)])
+        converged = all([clusters[i]==clusters_[i] for i in range(n)])
         clusters = clusters_
         if converged:
             break


### PR DESCRIPTION
When running "example_weighted.sh" I encountered an error:

```
Traceback (most recent call last):
  File "C:\Users\Niels\Documents\Thesis\MinSizeKmeans-master\minsize_kmeans\weighted_mm_kmeans.py", line 191, in <module>
    clusters, centers = minsize_kmeans_weighted(data, args.k, weights,
  File "C:\Users\Niels\Documents\Thesis\MinSizeKmeans-master\minsize_kmeans\weighted_mm_kmeans.py", line 127, in minsize_kmeans_weighted
    converged = all([clusters[i]==clusters_[i] for i in xrange(n)])
NameError: name 'xrange' is not defined
```
I think it was a typo and I changed it to range.

Edit: My bad, it was a Python 2 implementation. But now it seems to work in Python 3 😄 